### PR TITLE
Updated for CMSIS-Toolbox 1.4 (`interface:` nodes comment out as rena…

### DIFF
--- a/Board/AVH_MPS3_Corstone-300/Board.clayer.yml
+++ b/Board/AVH_MPS3_Corstone-300/Board.clayer.yml
@@ -7,17 +7,17 @@ layer:
   description: Board setup for IoT with VSocket and Ethernet interface
   # for device: ARM::SSE-300-MPS3
 
-  interfaces:
-    consumes:
-      - RTOS2:
-    provides:
-      - VSocket:
-      - C_ETH: 0
-      - C_VIO:
-      - STDOUT:
-      - STDIN:
-      - STDERR:
-      - Heap : 65536
+  #interfaces:
+  #  consumes:
+  #    - RTOS2:
+  #  provides:
+  #    - VSocket:
+  #    - C_ETH: 0
+  #    - C_VIO:
+  #    - STDOUT:
+  #    - STDIN:
+  #    - STDERR:
+  #    - Heap : 65536
 
   # packs:
   #   - pack: ARM::CMSIS

--- a/Board/B-U585I-IOT02A/Board.clayer.yml
+++ b/Board/B-U585I-IOT02A/Board.clayer.yml
@@ -7,20 +7,20 @@ layer:
   description: Board setup for IoT with WiFi interface
   # for-board: B-U585I-IOT02A
 
-  interfaces:
-    consumes:
-      - RTOS2:
-    provides:
-      - C_WiFi: 0
-      - A_UART: 3
-      - A_SPI: 1
-      - A_IO9_I:
-      - A_IO10_O:
-      - C_VIO:
-      - STDOUT:
-      - STDIN:
-      - STDERR:
-      - Heap : 65536
+  #interfaces:
+  #  consumes:
+  #    - RTOS2:
+  #  provides:
+  #    - C_WiFi: 0
+  #    - A_UART: 3
+  #    - A_SPI: 1
+  #    - A_IO9_I:
+  #    - A_IO10_O:
+  #    - C_VIO:
+  #    - STDOUT:
+  #    - STDIN:
+  #    - STDERR:
+  #    - Heap : 65536
 
   # packs:
   #   - pack: ARM::CMSIS

--- a/Board/IMXRT1050-EVKB/Board.clayer.yml
+++ b/Board/IMXRT1050-EVKB/Board.clayer.yml
@@ -7,20 +7,20 @@ layer:
   description: Board setup for IoT with WiFi and Ethernet interface
   # for-device: MIMXRT1052DVL6B
 
-  interfaces:
-    consumes:
-      - RTOS2:
-      # - A_UART: *     # Arduino module
-    provides:
-      # - C_WiFi: 0     # Arduino module
-      - C_ETH: 0
-      - C_MCI: 0
-      - A_UART: 3
-      - C_VIO:
-      - STDOUT:
-      - STDIN:
-      - STDERR:
-      - Heap : 65536
+  #interfaces:
+  #  consumes:
+  #    - RTOS2:
+  #    # - A_UART: *     # Arduino module
+  #  provides:
+  #    # - C_WiFi: 0     # Arduino module
+  #    - C_ETH: 0
+  #    - C_MCI: 0
+  #    - A_UART: 3
+  #    - C_VIO:
+  #    - STDOUT:
+  #    - STDIN:
+  #    - STDERR:
+  #    - Heap : 65536
 
   # packs:
   #   - pack: ARM::CMSIS

--- a/Demo.cproject.yml
+++ b/Demo.cproject.yml
@@ -11,17 +11,17 @@ project:
   #   - pack: AWS::corePKCS11@4.0.1
   #   - pack: Arm-Packs::PKCS11
 
-  interfaces:
-    provides:
-      - FreeRTOS:
-      - RTOS2:
-    consumes:
-      - IoT_Socket:
-      - C_VIO:
-      - STDOUT:
-      - STDIN:
-      - STDERR:
-      - Heap : 65536
+  #interfaces:
+  #  provides:
+  #    - FreeRTOS:
+  #    - RTOS2:
+  #  consumes:
+  #    - IoT_Socket:
+  #    - C_VIO:
+  #    - STDOUT:
+  #    - STDIN:
+  #    - STDERR:
+  #    - Heap : 65536
 
   add-path:
     - ./config_files

--- a/Socket/FreeRTOS+TCP/Socket.clayer.yml
+++ b/Socket/FreeRTOS+TCP/Socket.clayer.yml
@@ -6,13 +6,13 @@ layer:
   # variant: Ethernet
   description: IoT Socket interface using FreeRTOS+TCP over Ethernet
 
-  interfaces:
-    consumes:
-      - C_ETH: 0
-      - FreeRTOS:
-      - RTOS2:
-    provides:
-      - IoT_Socket:
+  #interfaces:
+  #  consumes:
+  #    - C_ETH: 0
+  #    - FreeRTOS:
+  #    - RTOS2:
+  #  provides:
+  #   - IoT_Socket:
 
   # packs:
   #   - pack: AWS::FreeRTOS-Plus-TCP@4.0.1

--- a/Socket/VSocket/Socket.clayer.yml
+++ b/Socket/VSocket/Socket.clayer.yml
@@ -5,11 +5,11 @@ layer:
   # name: VSocket
   description: IoT Socket interface using Virtual Socket on Arm Virtual Hardware
 
-  interfaces:
-    consumes:
-      - RTOS2:
-    provides:
-      - IoT_Socket:
+  #interfaces:
+  #  consumes:
+  #    - RTOS2:
+  #  provides:
+  #    - IoT_Socket:
 
   # packs:
   #   - pack: MDK-Packs::IoT_Socket

--- a/Socket/WiFi/Socket.clayer.yml
+++ b/Socket/WiFi/Socket.clayer.yml
@@ -5,11 +5,11 @@ layer:
   # name: WiFi
   description: IoT Socket interface using WiFi
 
-  interfaces:
-    consumes:
-      - C_WiFi: 0
-    provides:
-      - IoT_Socket:
+  #interfaces:
+  #  consumes:
+  #    - C_WiFi: 0
+  #  provides:
+  #    - IoT_Socket:
 
   # packs:
   #   - pack: MDK-Packs::IoT_Socket


### PR DESCRIPTION
…med to `connections:` in v1.4.0)