### PR TITLE
Move build-types out of cdefault

### DIFF
--- a/Board/AVH_MPS3_Corstone-300/Board.clayer.yml
+++ b/Board/AVH_MPS3_Corstone-300/Board.clayer.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   # type: Board

--- a/Board/B-U585I-IOT02A/Board.clayer.yml
+++ b/Board/B-U585I-IOT02A/Board.clayer.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   # type: Board

--- a/Board/IMXRT1050-EVKB/Board.clayer.yml
+++ b/Board/IMXRT1050-EVKB/Board.clayer.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   # type: Board

--- a/Demo.cdefault.yml
+++ b/Demo.cdefault.yml
@@ -1,51 +1,23 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/cdefault.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/cdefault.schema.json
 
 default:
   compiler: AC6
-
-  build-types:
-    - type: Debug
-      misc:
-        - for-compiler: AC6
-          C:
-            - -O1
-            - -g
-            - -Wno-macro-redefined
-            - -Wno-pragma-pack
-            - -Wno-parentheses-equality
-            - -std=c99
-          ASM:
-            - -masm=auto
-          Link:
-            - --entry=Reset_Handler
-        - for-compiler: GCC
-          C:
-            - -O1
-            - -g
-            - -Wall
-            - -std=gnu99
-          Link:
-            - --specs=nosys.specs
-            - --entry=Reset_Handler
-    - type: Release
-      misc:
-        - for-compiler: AC6
-          C:
-            - -O3
-            - -Wno-macro-redefined
-            - -Wno-pragma-pack
-            - -Wno-parentheses-equality
-            - -std=c99
-          ASM:
-            - -masm=auto
-          Link:
-            - --entry=Reset_Handler
-        - for-compiler: GCC
-          C:
-            - -O3
-            - -g
-            - -Wall
-            - -std=gnu99
-          Link:
-            - --specs=nosys.specs
-            - --entry=Reset_Handler
+  misc:
+    - for-compiler: AC6
+      ASM:
+        - -masm=auto
+      Link:
+        - --entry=Reset_Handler
+      C:
+        - -Wno-macro-redefined
+        - -Wno-pragma-pack
+        - -Wno-parentheses-equality
+        - -std=c99
+    - for-compiler: GCC
+      Link:
+        - --specs=nosys.specs
+        - --entry=Reset_Handler
+      C:
+        - -g
+        - -Wall
+        - -std=gnu99

--- a/Demo.cproject.yml
+++ b/Demo.cproject.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/cproject.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/cproject.schema.json
 
 project:
   # packs:
@@ -66,7 +66,7 @@ project:
 
   groups:
     - group: Documentation
-      files: 
+      files:
         - file: ./README.md
     - group: main
       files:
@@ -138,12 +138,12 @@ project:
 
     # Board
     - layer: ./Board/IMXRT1050-EVKB/Board.clayer.yml
-      for-type: 
+      for-type:
         - +IP-Stack
         # - +WiFi
     - layer: ./Board/B-U585I-IOT02A/Board.clayer.yml
-      for-type: 
+      for-type:
         - +WiFi
     - layer: ./Board/AVH_MPS3_Corstone-300/Board.clayer.yml
-      for-type: 
+      for-type:
         - +AVH

--- a/Demo.csolution.yml
+++ b/Demo.csolution.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/csolution.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/csolution.schema.json
 
 solution:
   packs:
@@ -33,6 +33,25 @@ solution:
       device: STMicroelectronics::STM32U585AIIx
     - type: AVH
       device: ARM::SSE-300-MPS3
+
+  build-types:
+    - type: Debug
+      misc:
+        - for-compiler: AC6
+          C:
+            - -O1
+            - -g
+        - for-compiler: GCC
+          C:
+            - -O1
+    - type: Release
+      misc:
+        - for-compiler: AC6
+          C:
+            - -O3
+        - for-compiler: GCC
+          C:
+            - -O3
 
   projects:
     - project: ./Demo.cproject.yml

--- a/Socket/FreeRTOS+TCP/Socket.clayer.yml
+++ b/Socket/FreeRTOS+TCP/Socket.clayer.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   # type: Socket

--- a/Socket/VSocket/Socket.clayer.yml
+++ b/Socket/VSocket/Socket.clayer.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   # type: Socket
@@ -19,6 +19,6 @@ layer:
 
   groups:
     - group: Socket
-      files: 
+      files:
         - file: ./socket_startup.c
         - file: ./iot_socket.c

--- a/Socket/WiFi/Socket.clayer.yml
+++ b/Socket/WiFi/Socket.clayer.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.2.0/tools/projmgr/schemas/clayer.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Open-CMSIS-Pack/devtools/schemas/projmgr/1.4.0/tools/projmgr/schemas/clayer.schema.json
 
 layer:
   # type: Socket
@@ -19,5 +19,5 @@ layer:
 
   groups:
     - group: Socket
-      files: 
+      files:
         - file: ./socket_startup.c


### PR DESCRIPTION
Defining build-types in the cdefault file is deprecated in the latest version of the schema:
https://github.com/Open-CMSIS-Pack/devtools/blob/75512df0147e04d14fc5f1eded047d1ff5b6c89d/tools/projmgr/schemas/common.schema.json#L471-L473